### PR TITLE
fix workflows 2 electric boogaloo

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -3,7 +3,7 @@
     "subproject_dir": "1.17.1"
   },
   {
-    "subproject_dir": "1.18.2"
+    "subproject_dir": "1.18.x"
   },
   {
     "subproject_dir": "1.19.x"

--- a/.github/workflows/scripts/summary.py
+++ b/.github/workflows/scripts/summary.py
@@ -24,7 +24,7 @@ with open(os.environ['GITHUB_STEP_SUMMARY'], 'w') as f:
 		subproject = m['subproject_dir']
 		if target_subproject != '' and subproject != target_subproject:
 			continue
-		game_versions = read_prop('versions/{}/gradle.properties'.format(subproject), 'game_versions')
+		game_versions = read_prop('versions/{}/gradle.properties'.format(subproject), 'minecraft_version')
 		game_versions = game_versions.strip().replace('\\n', ', ')
 		file_names = glob.glob('build-artifacts/{}/build/libs/*.jar'.format(subproject))
 		file_names = ', '.join(map(


### PR DESCRIPTION
this time an issue in the `summary.py` script references a `game_versions` property that should be `minecraft_version`

also updates the versions matrix to include `1.18.x` rather than `1.18.2`, to match that version's directory's name